### PR TITLE
Handle Short Timestamps in SRT & VTT Parsing

### DIFF
--- a/src/__tests__/srt.test.ts
+++ b/src/__tests__/srt.test.ts
@@ -403,4 +403,57 @@ Line with\u200Djoining char`;
     expect(result.cues[1].text).toBe('Text with\u2060word joiner\nLine with\u200Djoining char');
     expect(result.errors).toBeUndefined();
   });
+});
+
+describe('SRT Parser Timestamp Formats', () => {
+  test('handles short timestamp formats (MM:SS,mmm)', () => {
+    const input = `1
+01:30,000 --> 02:45,500
+Short timestamp format`;
+
+    const result = parseSRT(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].startTime).toBe(90000); // 1:30 in milliseconds
+    expect(result.cues[0].endTime).toBe(165500); // 2:45.5 in milliseconds
+    expect(result.errors).toBeUndefined();
+  });
+
+  test('handles ultra-short timestamp formats (SS.mmm)', () => {
+    const input = `1
+03.298 --> 04.578
+First line
+
+2
+04.578 --> 06.178
+Second line`;
+
+    const result = parseSRT(input);
+    expect(result.cues).toHaveLength(2);
+    expect(result.cues[0].startTime).toBe(3298);
+    expect(result.cues[0].endTime).toBe(4578);
+    expect(result.cues[1].startTime).toBe(4578);
+    expect(result.cues[1].endTime).toBe(6178);
+    expect(result.errors).toBeUndefined();
+  });
+
+  test('handles mixed timestamp formats in the same file', () => {
+    const input = `1
+03.298 --> 04.578
+First line
+
+2
+00:04.578 --> 00:06.178
+Second line
+
+3
+00:00:06.178 --> 00:00:07.518
+Third line`;
+
+    const result = parseSRT(input);
+    expect(result.cues).toHaveLength(3);
+    expect(result.cues[0].startTime).toBe(3298);
+    expect(result.cues[1].startTime).toBe(4578);
+    expect(result.cues[2].startTime).toBe(6178);
+    expect(result.errors).toBeUndefined();
+  });
 }); 

--- a/src/__tests__/vtt.test.ts
+++ b/src/__tests__/vtt.test.ts
@@ -407,4 +407,63 @@ describe('VTT Generator', () => {
     const output = generateVTT(vtt);
     expect(output).toContain('intro\n1:00.000');
   });
+});
+
+describe('VTT Parser Timestamp Formats', () => {
+  test('handles short timestamp formats (MM:SS.mmm)', () => {
+    const input = `WEBVTT
+
+1
+01:30.000 --> 02:45.500
+Short timestamp format`;
+
+    const result = parseVTT(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].startTime).toBe(90000); // 1:30 in milliseconds
+    expect(result.cues[0].endTime).toBe(165500); // 2:45.5 in milliseconds
+    expect(result.errors).toBeUndefined();
+  });
+
+  test('handles ultra-short timestamp formats (SS.mmm)', () => {
+    const input = `WEBVTT
+
+1
+03.298 --> 04.578
+First line
+
+2
+04.578 --> 06.178
+Second line`;
+
+    const result = parseVTT(input);
+    expect(result.cues).toHaveLength(2);
+    expect(result.cues[0].startTime).toBe(3298);
+    expect(result.cues[0].endTime).toBe(4578);
+    expect(result.cues[1].startTime).toBe(4578);
+    expect(result.cues[1].endTime).toBe(6178);
+    expect(result.errors).toBeUndefined();
+  });
+
+  test('handles mixed timestamp formats in the same file', () => {
+    const input = `WEBVTT
+
+1
+03.298 --> 04.578
+First line
+
+2
+00:04.578 --> 00:06.178
+Second line
+
+3
+00:00:06.178 --> 00:00:07.518
+Third line`;
+
+    const result = parseVTT(input);
+    expect(result.cues).toHaveLength(3);
+    expect(result.cues[0].startTime).toBe(3298);
+    expect(result.cues[1].startTime).toBe(4578);
+    expect(result.cues[2].startTime).toBe(6178);
+    expect(result.errors).toBeUndefined();
+  });
 }); 

--- a/src/core-utils.ts
+++ b/src/core-utils.ts
@@ -51,9 +51,36 @@ export const detectFormat = (content: string): FormatDetectionResult => {
  * Common time parsing utility
  */
 export const parseTimeString = (timeStr: string): number => {
-    const [time, ms] = timeStr.split(',');
-    const [hours, minutes, seconds] = time.split(':').map(Number);
-    return (hours * 3600 + minutes * 60 + seconds) * 1000 + parseInt(ms || '0');
+    // Normalize the timestamp format
+    timeStr = timeStr.trim();
+    
+    // Handle SS.mmm format
+    if (timeStr.match(/^\d+\.\d+$/)) {
+        const [seconds, ms] = timeStr.split('.');
+        return parseInt(seconds) * 1000 + parseInt(ms.padEnd(3, '0'));
+    }
+    
+    // Handle MM:SS,mmm or MM:SS.mmm format
+    if (timeStr.match(/^\d{1,2}:\d{2}[,\.]\d{3}$/)) {
+        const [time, ms] = timeStr.split(/[,\.]/);
+        const [minutes, seconds] = time.split(':').map(Number);
+        return (minutes * 60 + seconds) * 1000 + parseInt(ms);
+    }
+    
+    // Handle HH:MM:SS,mmm format
+    const parts = timeStr.split(/[,\.]/);
+    const time = parts[0];
+    const ms = parts[1] || '000';
+    
+    const timeParts = time.split(':').map(Number);
+    
+    // Pad with zeros if parts are missing
+    while (timeParts.length < 3) {
+        timeParts.unshift(0);
+    }
+    
+    const [hours, minutes, seconds] = timeParts;
+    return (hours * 3600 + minutes * 60 + seconds) * 1000 + parseInt(ms.padEnd(3, '0'));
 };
 
 /**


### PR DESCRIPTION
This PR updates the **core-utils** module to support parsing of short timestamp formats in both **SRT** and **VTT** subtitles. Previously, the parser expected timestamps to follow the `HH:MM:SS,mmm` format, but this update adds support for:  

- **Ultra-short format:** `SS.mmm`  
- **Short format:** `MM:SS,mmm` or `MM:SS.mmm`  
- **Mixed format:** Allows different timestamp formats within the same file  

## Changes  
- **Updated `parseTimeString`** function to handle multiple timestamp formats  
- **Added unit tests** for:  
  - `SS.mmm` timestamps  
  - `MM:SS,mmm` and `MM:SS.mmm` formats  
  - Mixed timestamp formats within the same subtitle file  
- **Refactored existing logic** to normalize and pad timestamps where necessary  

## Impact  
- Fixes potential parsing issues for subtitles using short timestamp formats  
- Ensures better compatibility with varied subtitle sources  

## Testing  
- Added test cases in `srt.test.ts` and `vtt.test.ts` to cover all new formats  
- Verified no breaking changes to existing timestamp parsing  

-- **100% vibe-coded** --