### PR TITLE
Correct VTT timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The `parse()` function will automatically detect whether your content is SRT or 
 ### Converting Between Formats
 
 ```typescript
-import { parse, generateSRT, generateVTT, resync } from 'subvibe';
+import { parse, generateSRT, generateVTT, resync, build } from 'subvibe';
 
 // Parse any subtitle format
 const result = parse(content);
@@ -75,6 +75,11 @@ const vttContent = generateVTT(result);
 
 // Convert to SRT
 const srtContent = generateSRT(result);
+
+// Build subtitles in any format from cues
+const textContent = build(result.cues);                 // Plain text
+const srtContent = build(result.cues, 'srt');          // SRT format
+const vttContent = build(result.cues, 'vtt');          // VTT format
 ```
 
 ### Working with Subtitles Programmatically
@@ -110,6 +115,21 @@ Auto-detect and parse subtitle content in either SRT or WebVTT format.
 const result = parse(content);
 console.log(result.type);    // 'srt' or 'vtt'
 console.log(result.cues);    // parsed subtitle cues
+```
+
+#### `build(cues: SubtitleCue[], format?: 'text' | 'srt' | 'vtt'): string`
+
+Generate subtitle content in various formats from an array of cues. The default format is 'text'.
+
+```typescript
+// Generate plain text (default)
+const textContent = build(cues);
+
+// Generate SRT format
+const srtContent = build(cues, 'srt');
+
+// Generate VTT format
+const vttContent = build(cues, 'vtt');
 ```
 
 #### `resync(cues: SubtitleCue[], options: TimeShiftOptions): SubtitleCue[]`

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -1,5 +1,4 @@
-import { generateSRT } from '../srt/generator';
-import { parse, resync, SubtitleCue } from '../index';
+import { generateSRT, generateVTT, parse, resync, SubtitleCue } from '../index';
 
     // Sample subtitle cues for three different tracks
     const subtitles = [
@@ -40,5 +39,31 @@ describe('Merge and Offset Tests', () => {
     //check "Get out of here" is at the end of the output and timestamp is shifted, should be +24 mins
     expect(srtOutput).toContain("00:24:45,000 --> 00:24:46,000\nGet out of here.");
 
+  });
+
+  it('should merge three texts with different time offsets correctly to VTT', () => {
+    const results: SubtitleCue[] = []
+    for(let i = 0; i < subtitles.length; i++) {
+      const subtitle = subtitles[i];
+      const offset = offsets[i] * 1000;
+      const parsed = parse(subtitle);
+      const resynced = resync(parsed.cues, { offset });
+      results.push(...resynced);
+    }
+
+    const vttOutput = generateVTT(results.flat());
+
+    // Verify the output
+    //check "Ladies and gentlemen" is in the output and timestamp is not shifted
+    expect(vttOutput).toContain("00:00.000 --> 00:06.960\nLadies and gentlemen");
+
+    //check "I'm from future" is in the output and timestamp is shifted, should be +16 mins
+    expect(vttOutput).toContain("16:24.779 --> 16:32.380\nI'm from future 8");
+    
+    //check "Get out of here" is at the end of the output and timestamp is shifted, should be +24 mins
+    expect(vttOutput).toContain("24:45.000 --> 24:46.000\nGet out of here.");
+
+    // Verify VTT header
+    expect(vttOutput.startsWith('WEBVTT\n\n')).toBe(true);
   });
 });

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -1,0 +1,44 @@
+import { generateSRT } from '../srt/generator';
+import { parse, resync, SubtitleCue } from '../index';
+
+    // Sample subtitle cues for three different tracks
+    const subtitles = [
+      "WEBVTT\n\n00:00:00.000 --> 00:00:06.960\nLadies and gentlemen\n\n00:00:06.960 --> 00:00:10.920\nAI crisis.\n\n00:00:10.920 --> 00:00:15.880\nNow,\n\n00:00:15.880 --> 00:00:20.260\n their\n\n00:08:06.260 --> 00:08:10.299\nSo so far, like.\n\n00:08:10.299 --> 00:08:14.339\nIt's taking a long time\n\n00:08:14.339 --> 00:08:18.899\nhere, and, you know.\n\n00:08:18.899 --> 00:08:19.899\nWhat can I say?\n",
+      "WEBVTT\n\n00:00:00.000 --> 00:00:06.500\nSo,\n\n00:00:06.500 --> 00:00:09.480\nhad prepared,\n\n00:08:04.779 --> 00:08:12.380\nI'm from future 8\n\n00:08:12.380 --> 00:08:20.059\nand forced.\n\n",
+      "WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nIm closer 0.\n\n00:00:08.000 --> 00:00:11.000\nI should be at the end 20+.\n\n\n\n00:08:04.000 --> 00:08:05.000\nThat's all.\n\n00:08:05.000 --> 00:08:06.000\nGet out of here.\n\n",
+    ]
+
+    // Time offsets for each subtitle track in seconds
+    const offsets = [
+      0,
+      500, // 8 minutes and 20 seconds
+      1000, // 16 minutes and 40 seconds
+    ]
+
+describe('Merge and Offset Tests', () => {
+  it('should merge three texts with different time offsets correctly to SRT', () => {
+
+    const results: SubtitleCue[] = []
+    for(let i = 0; i < subtitles.length; i++) {
+      const subtitle = subtitles[i];
+      const offset = offsets[i] * 1000; // Convert to milliseconds
+      const parsed = parse(subtitle);
+      const resynced = resync(parsed.cues, { offset });
+      results.push(...resynced);
+    }
+
+    const srtOutput = generateSRT(results.flat());
+
+
+    // Verify the output
+    //check "Ladies and gentlemen" is in the output and timestamp is not shifted
+    expect(srtOutput).toContain("00:00:00,000 --> 00:00:06,960\nLadies and gentlemen");
+
+    //check "I'm from future" is in the output and timestamp is shifted, should be +16 mins
+    expect(srtOutput).toContain("00:16:24,779 --> 00:16:32,380\nI'm from future 8");
+    
+    //check "Get out of here" is at the end of the output and timestamp is shifted, should be +24 mins
+    expect(srtOutput).toContain("00:24:45,000 --> 00:24:46,000\nGet out of here.");
+
+  });
+});

--- a/src/__tests__/vtt.test.ts
+++ b/src/__tests__/vtt.test.ts
@@ -269,9 +269,9 @@ describe('VTT Generator', () => {
     const output = generateVTT(vtt);
     expect(output).toBe(
       'WEBVTT\n\n' +
-      '1:00.000 --> 4:00.000\n' +
+      '00:01.000 --> 00:04.000\n' +
       'Hello world!\n\n' +
-      '5:00.000 --> 8:00.000\n' +
+      '00:05.000 --> 00:08.000\n' +
       'Second subtitle\n'
     );
   });
@@ -374,22 +374,22 @@ describe('VTT Generator', () => {
       cues: [
         {
           index: 1,
-          startTime: 1000,
-          endTime: 4000,
+          startTime: 1000,  // 1 second
+          endTime: 4000,    // 4 seconds
           text: 'No hours'
         },
         {
           index: 2,
-          startTime: 3600000,
-          endTime: 3605000,
+          startTime: 3600000,  // 1 hour
+          endTime: 3605000,    // 1 hour and 5 seconds
           text: 'With hours'
         }
       ]
     };
 
     const output = generateVTT(vtt);
-    expect(output).toContain('1:00.000 --> 4:00.000');
-    expect(output).toContain('01:00:00.000 --> 01:00:05.000');
+    expect(output).toContain('00:01.000 --> 00:04.000'); // mm:ss.ttt format
+    expect(output).toContain('01:00:00.000 --> 01:00:05.000'); // hh:mm:ss.ttt format
   });
 
   test('handles custom identifiers', () => {
@@ -405,7 +405,7 @@ describe('VTT Generator', () => {
     };
 
     const output = generateVTT(vtt);
-    expect(output).toContain('intro\n1:00.000');
+    expect(output).toContain('intro\n00:01.000');
   });
 });
 
@@ -466,4 +466,4 @@ Third line`;
     expect(result.cues[2].startTime).toBe(6178);
     expect(result.errors).toBeUndefined();
   });
-}); 
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { parseSRT } from './srt/parser';
 import { parseVTT } from './vtt/parser';
-import { generateSRT } from './srt/generator';
+import { generateSRT, formatTimestamp } from './srt/generator';
 import { generateVTT } from './vtt/generator';
 import { SubtitleUtils } from './utils';
 import { ParsedSubtitles, SubtitleCue, TimeShiftOptions } from './types';
@@ -91,7 +91,8 @@ const SubVibe = {
     parseVTT,
     generateSRT,
     generateVTT,
-    SubtitleUtils
+    SubtitleUtils,
+    formatTimestamp
 };
 
 // Export both named exports and default export
@@ -103,7 +104,8 @@ export {
     parseVTT,
     generateSRT,
     generateVTT,
-    SubtitleUtils
+    SubtitleUtils,
+    formatTimestamp
 };
 
 export default SubVibe;

--- a/src/srt/generator.ts
+++ b/src/srt/generator.ts
@@ -19,7 +19,7 @@ function millisecondsToTimeComponents(ms: number): TimeComponents {
   return { hours, minutes, seconds, milliseconds };
 }
 
-function formatTimestamp(ms: number): string {
+export function formatTimestamp(ms: number): string {
   const time = millisecondsToTimeComponents(ms);
   return `${formatTimeComponent(time.hours)}:${formatTimeComponent(time.minutes)}:${formatTimeComponent(time.seconds)},${formatMilliseconds(time.milliseconds)}`;
 }


### PR DESCRIPTION
This pull request includes several changes to improve subtitle handling and formatting in the codebase. The most important changes involve adding new tests for merging and offsetting subtitle tracks, modifying timestamp formatting, and updating the `generateVTT` function to handle different input types.

### New Tests for Subtitle Handling:
* Added tests in `src/__tests__/generator.test.ts` for merging and offsetting subtitle tracks with different time offsets to both SRT and VTT formats. These tests ensure that subtitles are correctly merged and timestamps are accurately shifted.

### Timestamp Formatting:
* Exported the `formatTimestamp` function from `src/srt/generator.ts` to make it available for external use. This function formats timestamps in the SRT format.

### Modifications in VTT Timestamp Formatting:
* Updated the `formatVTTTimestamp` function in `src/vtt/generator.ts` to correctly format timestamps as `mm:ss.ttt` for durations less than 1 hour and `hh:mm:ss.ttt` for durations of 1 hour or more.

### Updates to `generateVTT` Function:
* Modified the `generateVTT` function in `src/vtt/generator.ts` to handle both `ParsedVTT` objects and arrays of `SubtitleCue` objects. This change allows for more flexibility in generating VTT subtitles from different input types. [[1]](diffhunk://#diff-441cb239607aaa3486af8bb81a3722fd8ad19e8032681a82ecc8c0725323c330L47-R80) [[2]](diffhunk://#diff-441cb239607aaa3486af8bb81a3722fd8ad19e8032681a82ecc8c0725323c330L70-R91)

### Minor Test Adjustments:
* Adjusted existing tests in `src/__tests__/vtt.test.ts` to reflect the new timestamp formatting rules, ensuring consistency across the codebase. [[1]](diffhunk://#diff-b87b94b86047d3364bf768c289cd0bb585b59b28aab2bcd9bf1cdc592b122186L272-R274) [[2]](diffhunk://#diff-b87b94b86047d3364bf768c289cd0bb585b59b28aab2bcd9bf1cdc592b122186L377-R392) [[3]](diffhunk://#diff-b87b94b86047d3364bf768c289cd0bb585b59b28aab2bcd9bf1cdc592b122186L408-R408)