### PR TITLE
Add support for preserveIndexes option in SRT and VTT parsers and generators

### DIFF
--- a/src/__tests__/build.test.ts
+++ b/src/__tests__/build.test.ts
@@ -1,0 +1,77 @@
+import { build } from '../index';
+
+describe('build function', () => {
+    const testCues = [
+        { index: 1, startTime: 1000, endTime: 4000, text: 'First' },
+        { index: 35, startTime: 4500, endTime: 8000, text: 'Second' },
+        { index: 77, startTime: 8500, endTime: 12000, text: 'Third' }
+    ];
+
+    test('should build SRT with preserved indexes', () => {
+        const result = build(testCues, { format: 'srt', preserveIndexes: true });
+        
+        expect(result).toContain('35');
+        expect(result).toContain('77');
+        expect(result).toMatch(/35\n00:00:04,500 --> 00:00:08,000\nSecond/);
+    });
+
+    test('should build SRT with sequential indexes', () => {
+        const result = build(testCues, { format: 'srt' });
+        
+        expect(result).not.toContain('35');
+        expect(result).toMatch(/2\n00:00:04,500 --> 00:00:08,000\nSecond/);
+    });
+
+    test('should build VTT with preserved indexes', () => {
+        const result = build(testCues, { format: 'vtt', preserveIndexes: true });
+        
+        expect(result).toContain('WEBVTT');
+        expect(result).toContain('35');
+        expect(result).toMatch(/35\n00:04\.500 --> 00:08\.000\nSecond/);
+    });
+
+    test('should build plain text', () => {
+        const result = build(testCues, { format: 'text' });
+        
+        expect(result).toBe('First\n\nSecond\n\nThird');
+    });
+
+    test('should support legacy string format parameter', () => {
+        const result = build(testCues, 'srt');
+        
+        expect(result).toMatch(/1\n00:00:01,000 --> 00:00:04,000\nFirst/);
+        expect(result).toMatch(/2\n00:00:04,500 --> 00:00:08,000\nSecond/);
+    });
+
+    test('should handle ParsedSubtitles input', () => {
+        const parsedInput = {
+            type: 'srt' as const,
+            cues: testCues
+        };
+        
+        const result = build(parsedInput);
+        expect(result).toMatch(/1\n00:00:01,000 --> 00:00:04,000\nFirst/);
+    });
+
+    test('should respect input type when no format specified', () => {
+        const parsedInput = {
+            type: 'vtt' as const,
+            cues: testCues
+        };
+        
+        const result = build(parsedInput);
+        expect(result).toContain('WEBVTT');
+        expect(result).toMatch(/1\n00:01\.000 --> 00:04\.000\nFirst/);
+    });
+
+    test('should override input type with format option', () => {
+        const parsedInput = {
+            type: 'vtt' as const,
+            cues: testCues
+        };
+        
+        const result = build(parsedInput, { format: 'srt' });
+        expect(result).not.toContain('WEBVTT');
+        expect(result).toMatch(/1\n00:00:01,000 --> 00:00:04,000\nFirst/);
+    });
+});

--- a/src/__tests__/fixtures/sample.srt
+++ b/src/__tests__/fixtures/sample.srt
@@ -1,0 +1,12 @@
+1
+00:00:01,000 --> 00:00:04,000
+First subtitle
+
+35
+00:00:04,500 --> 00:00:08,000
+Second subtitle with
+multiple lines
+
+77
+00:00:08,500 --> 00:00:12,000
+Third subtitle

--- a/src/__tests__/fixtures/sample.vtt
+++ b/src/__tests__/fixtures/sample.vtt
@@ -1,0 +1,14 @@
+WEBVTT
+
+1
+00:01.000 --> 00:04.000
+First subtitle
+
+35
+00:04.500 --> 00:08.000
+Second subtitle with
+multiple lines
+
+77
+00:08.500 --> 00:12.000
+Third subtitle

--- a/src/__tests__/parse.test.ts
+++ b/src/__tests__/parse.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parse } from '../index';
+
+describe('parse function', () => {
+    const srtContent = readFileSync(join(__dirname, 'fixtures/sample.srt'), 'utf-8');
+    const vttContent = readFileSync(join(__dirname, 'fixtures/sample.vtt'), 'utf-8');
+
+    test('should correctly parse SRT content', () => {
+        const result = parse(srtContent, { preserveIndexes: true });
+        
+        expect(result.type).toBe('srt');
+        expect(result.cues).toHaveLength(3);
+        expect(result.cues[0]).toEqual({
+            index: 1,
+            startTime: 1000,
+            endTime: 4000,
+            text: 'First subtitle'
+        });
+    });
+
+    test('should correctly parse VTT content', () => {
+        const result = parse(vttContent, { preserveIndexes: true });
+        
+        expect(result.type).toBe('vtt');
+        expect(result.cues).toHaveLength(3);
+        expect(result.cues[1]).toEqual({
+            index: 35,
+            startTime: 4500,
+            endTime: 8000,
+            text: 'Second subtitle with\nmultiple lines'
+        });
+    });
+
+    test('should use sequential indexes when preserveIndexes is false', () => {
+        const result = parse(vttContent, { preserveIndexes: false });
+        
+        expect(result.type).toBe('vtt');
+        expect(result.cues).toHaveLength(3);
+        expect(result.cues[1].index).toBe(2);
+    });
+
+    test('should handle invalid content', () => {
+        const result = parse('invalid content');
+        
+        expect(result.type).toBe('unknown');
+        expect(result.cues).toHaveLength(0);
+        expect(result.errors).toBeDefined();
+    });
+});

--- a/src/__tests__/parse2.test.ts
+++ b/src/__tests__/parse2.test.ts
@@ -1,0 +1,23 @@
+import { parse } from '../index';
+
+describe('parse with preserveIndexes option', () => {
+    test('should preserve original indexes when option is set', () => {
+        const srtContent = `35
+00:00:04,500 --> 00:00:08,000
+Second subtitle with
+multiple lines`;
+
+        const result = parse(srtContent, { preserveIndexes: true });
+        expect(result.cues[0].index).toBe(35);
+    });
+
+    test('should use sequential indexes when preserveIndexes is false', () => {
+        const srtContent = `35
+00:00:04,500 --> 00:00:08,000
+Second subtitle with
+multiple lines`;
+
+        const result = parse(srtContent, { preserveIndexes: false });
+        expect(result.cues[0].index).toBe(1);
+    });
+});

--- a/src/__tests__/resync.test.ts
+++ b/src/__tests__/resync.test.ts
@@ -1,0 +1,38 @@
+import { resync } from '../index';
+
+describe('resync function', () => {
+    const testCues = [
+        { index: 1, startTime: 1000, endTime: 4000, text: 'First' },
+        { index: 2, startTime: 4500, endTime: 8000, text: 'Second' },
+        { index: 3, startTime: 8500, endTime: 12000, text: 'Third' }
+    ];
+
+    test('should shift all timestamps forward', () => {
+        const shifted = resync(testCues, { offset: 2000 });
+        
+        expect(shifted[0].startTime).toBe(3000);
+        expect(shifted[0].endTime).toBe(6000);
+        expect(shifted[0].original).toEqual({
+            startTime: 1000,
+            endTime: 4000
+        });
+    });
+
+    test('should shift all timestamps backward', () => {
+        const shifted = resync(testCues, { offset: -1000 });
+        
+        expect(shifted[0].startTime).toBe(0);
+        expect(shifted[1].startTime).toBe(3500);
+    });
+
+    test('should shift timestamps only after startAt', () => {
+        const shifted = resync(testCues, { 
+            offset: 1000,
+            startAt: 5000
+        });
+        
+        expect(shifted[0].startTime).toBe(1000); // unchanged
+        expect(shifted[1].startTime).toBe(5500); // shifted
+        expect(shifted[2].startTime).toBe(9500); // shifted
+    });
+});

--- a/src/__tests__/vtt.test.ts
+++ b/src/__tests__/vtt.test.ts
@@ -248,29 +248,21 @@ Just seconds`;
 
 describe('VTT Generator', () => {
   test('generates basic VTT content', () => {
-    const vtt: ParsedVTT = {
-      type: 'vtt',
+    const vtt = {
+      type: 'vtt' as const,
       cues: [
-        {
-          index: 1,
-          startTime: 1000,
-          endTime: 4000,
-          text: 'Hello world!'
-        },
-        {
-          index: 2,
-          startTime: 5000,
-          endTime: 8000,
-          text: 'Second subtitle'
-        }
+        { index: 1, startTime: 1000, endTime: 4000, text: 'Hello world!' },
+        { index: 2, startTime: 5000, endTime: 8000, text: 'Second subtitle' }
       ]
     };
 
     const output = generateVTT(vtt);
     expect(output).toBe(
       'WEBVTT\n\n' +
+      '1\n' +
       '00:01.000 --> 00:04.000\n' +
       'Hello world!\n\n' +
+      '2\n' +
       '00:05.000 --> 00:08.000\n' +
       'Second subtitle\n'
     );
@@ -393,8 +385,8 @@ describe('VTT Generator', () => {
   });
 
   test('handles custom identifiers', () => {
-    const vtt: ParsedVTT = {
-      type: 'vtt',
+    const vtt = {
+      type: 'vtt' as const,
       cues: [{
         index: 1,
         identifier: 'intro',

--- a/src/srt/generator.ts
+++ b/src/srt/generator.ts
@@ -24,15 +24,20 @@ export function formatTimestamp(ms: number): string {
   return `${formatTimeComponent(time.hours)}:${formatTimeComponent(time.minutes)}:${formatTimeComponent(time.seconds)},${formatMilliseconds(time.milliseconds)}`;
 }
 
-export function generateSRT(subtitles: ParsedSubtitles | SubtitleCue[]): string {
-  const cues = Array.isArray(subtitles) ? subtitles : subtitles.cues;
+export function generateSRT(input: ParsedSubtitles | SubtitleCue[], options: { preserveIndexes?: boolean } = {}): string {
+  const cues = Array.isArray(input) ? input : input.cues;
+  
   return cues
-    .map((cue: SubtitleCue, index: number) => {
-      const number = index + 1;
-      const timestamp = `${formatTimestamp(cue.startTime)} --> ${formatTimestamp(cue.endTime)}`;
-      return `${number}\n${timestamp}\n${cue.text}`;
+    .map((cue, index) => {
+      const sequenceNumber = options.preserveIndexes ? (cue.index || index + 1) : index + 1;
+      return [
+        sequenceNumber,
+        `${formatTimestamp(cue.startTime)} --> ${formatTimestamp(cue.endTime)}`,
+        cue.text,
+        ''
+      ].join('\n');
     })
-    .join('\n\n') + '\n';
+    .join('\n');
 }
 
 // Optional utility function to convert VTT cues to SRT format

--- a/src/srt/parser.ts
+++ b/src/srt/parser.ts
@@ -1,4 +1,4 @@
-import { ParsedSubtitles, ParseError, SubtitleCue } from '../types';
+import { ParsedSubtitles, ParseError, SubtitleCue, ParseOptions } from '../types';
 import { parseTimeString, hasTimestamp, findTimestampRange } from '../core-utils';
 import { parser as log } from '../utils/debug';
 
@@ -56,7 +56,7 @@ export function parseTimestamp(timestamp: string): number {
   }
 }
 
-export function parseSRT(content: string): ParsedSubtitles {
+export function parseSRT(content: string, options: ParseOptions = {}): ParsedSubtitles {
   const lines = content.trim().split(/\r?\n/);
   log("\n=== Starting new parse ===");
   log("Input lines:", lines);
@@ -173,12 +173,13 @@ export function parseSRT(content: string): ParsedSubtitles {
         }
 
         currentIndex++;
-        cues.push({
-          index: currentIndex,
+        const cue = {
+          index: options.preserveIndexes ? lastSeenIndex : currentIndex,
           startTime,
           endTime,
           text
-        });
+        };
+        cues.push(cue);
 
         if (!parsingCue) {
           errors.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,3 +94,12 @@ export interface TimeShiftOptions {
    */
   endAt?: number;
 }
+
+export interface BuildOptions {
+  format?: 'text' | 'srt' | 'vtt';
+  preserveIndexes?: boolean;
+}
+
+export interface ParseOptions {
+  preserveIndexes?: boolean;
+}

--- a/src/vtt/parser.ts
+++ b/src/vtt/parser.ts
@@ -1,4 +1,4 @@
-import { /* SubtitleCue, ParsedSubtitles, */ ParseError, ParsedVTT, VTTCue, VTTCueSettings, VTTRegion, /* VTTStyles, */ VTTVoice } from '../types';
+import { /* SubtitleCue, ParsedSubtitles, */ ParseError, ParsedVTT, VTTCue, VTTCueSettings, VTTRegion, /* VTTStyles, */ VTTVoice, ParseOptions } from '../types';
 import { parser as log } from '../utils/debug';
 
 function normalizeTimestamp(timestamp: string): string {
@@ -195,7 +195,12 @@ function parseVoiceSpans(text: string): { voice: string; text: string }[] | unde
   }));
 }
 
-export function parseVTT(content: string): ParsedVTT {
+function parseCueIndex(line: string): number | null {
+  const num = parseInt(line, 10);
+  return !isNaN(num) ? num : null;
+}
+
+export function parseVTT(content: string, options: ParseOptions = {}): ParsedVTT {
   const lines = content.trim().split(/\r?\n/);
   const cues: VTTCue[] = [];
   const errors: ParseError[] = [];
@@ -365,9 +370,9 @@ export function parseVTT(content: string): ParsedVTT {
       // Parse voices and clean text
       const { text: cleanText, voices } = parseVTTVoices(text.trim());
 
-      // Create cue with only defined fields
+      // Create cue with properly handled index
       const cue: VTTCue = {
-        index: currentIndex + 1,
+        index: options.preserveIndexes ? (parseCueIndex(identifier) || currentIndex + 1) : currentIndex + 1,
         startTime,
         endTime,
         text: cleanText


### PR DESCRIPTION
Introduce the `preserveIndexes` option to maintain original cue indexes during parsing and generation of SRT and VTT subtitles. Update relevant functions and tests to ensure correct behavior with this new option.