### PR TITLE
Always end VTT with newline - simplifies things

### DIFF
--- a/src/__tests__/vtt.test.ts
+++ b/src/__tests__/vtt.test.ts
@@ -479,7 +479,8 @@ question
 The possibilities endless.
 
 00:14.160 --> 00:17.240
-It's not just about the generative AI itself.`;
+It's not just about the generative AI itself.
+`;
 
   it('should preserve identifiers when preserveIndexes is true', () => {
     const parsed = parse(input, { preserveIndexes: true }) as ParsedVTT;

--- a/src/vtt/generator.ts
+++ b/src/vtt/generator.ts
@@ -110,14 +110,7 @@ export function generateVTT(subtitles: ParsedVTT | SubtitleCue[], options: { pre
   });
 
   const output = blocks.join('\n\n');
-  // For parsed content that originally had explicit identifiers (preserveIndexes true),
-  // we return output exactly (to match the original input, which has no trailing newline).
-  // Otherwise, always append a trailing newline.
-  if (isParsedVTT && options.preserveIndexes && hasAnyIdentifiers) {
-    return output;
-  } else {
-    return output + '\n';
-  }
+  return output + '\n';
 }
 
 // Optional utility function to convert SRT cues to VTT format


### PR DESCRIPTION
This pull request includes changes to the `src/__tests__/vtt.test.ts` and `src/vtt/generator.ts` files to improve the handling of trailing newlines in VTT (WebVTT) subtitle files. The most important changes involve ensuring consistent output formatting by always appending a trailing newline.

Improvements to VTT file handling:

* [`src/__tests__/vtt.test.ts`](diffhunk://#diff-b87b94b86047d3364bf768c289cd0bb585b59b28aab2bcd9bf1cdc592b122186L482-R483): Added a trailing newline in the test string to ensure consistency in test cases.

Codebase simplification:

* [`src/vtt/generator.ts`](diffhunk://#diff-441cb239607aaa3486af8bb81a3722fd8ad19e8032681a82ecc8c0725323c330L113-L121): Simplified the `generateVTT` function by removing the conditional logic for appending a trailing newline and ensuring that a newline is always appended to the output.