### PR TITLE
Fix for VTT that has no empty lines

### DIFF
--- a/src/__tests__/fixtures/subnospacing.vtt
+++ b/src/__tests__/fixtures/subnospacing.vtt
@@ -1,0 +1,335 @@
+ WEBVTT
+
+1
+00:00:00.424 --> 00:00:01.464
+The end of programming
+2
+00:00:01.464 --> 00:00:02.744
+as we know it.
+3
+00:00:03.354 --> 00:00:04.864
+We got an we got ourselves
+4
+00:00:04.864 --> 00:00:05.314
+an O'Reilly article.
+5
+00:00:05.844 --> 00:00:10.044
+I went and checked the length of this and if this is new, it is new.
+6
+00:00:10.044 --> 00:00:11.994
+And so, here we go.
+7
+00:00:11.994 --> 00:00:15.044
+We're doing this the end of programming
+8
+00:00:15.044 --> 00:00:15.674
+as we know it.
+9
+00:00:15.674 --> 00:00:21.304
+Yet again another faithful article to the current state of the times.
+10
+00:00:21.304 --> 00:00:25.114
+This time by O'Reilly, who makes their money off of selling
+11
+00:00:25.114 --> 00:00:28.084
+programming books has written an article
+12
+00:00:28.084 --> 00:00:28.784
+called the end of programming
+13
+00:00:28.784 --> 00:00:30.004
+as we know it.
+14
+00:00:30.004 --> 00:00:32.264
+This is going to be great.
+15
+00:00:32.264 --> 00:00:34.954
+I mean, I'm not sure what O'Reilly's trying to do here,
+16
+00:00:35.094 --> 00:00:39.344
+but it kind of seems counterintuitive.
+17
+00:00:39.344 --> 00:00:42.194
+And this is by Timothy O'Reilly.
+18
+00:00:42.404 --> 00:00:47.004
+Like this guy, this is Timothy O'Reilly, like Timotheus O'Reilly.
+19
+00:00:47.004 --> 00:00:47.974
+All right, there's a lot of chatter
+20
+00:00:47.974 --> 00:00:56.274
+in media that software developers will soon lose their jobs to AI, I don't buy it.
+21
+00:00:56.274 --> 00:00:59.674
+Oh my gosh.
+22
+00:00:59.674 --> 01:03.364
+Wait a second, did I just get jabaited by this article
+23
+01:03.364 --> 01:04.724
+and are we about to get hit with some
+24
+01:04.724 --> 01:10.024
+straight facts from O'Reilly software.
+25
+01:09.994 --> 01:10.914
+It is not the end of programming.
+26
+01:10.914 --> 01:16.164
+It is the end of programming as we know it today.
+27
+01:16.164 --> 01:16.754
+That is not new.
+28
+01:16.754 --> 01:22.084
+The first programmers connected physical circuits to perform each calculation.
+29
+01:22.084 --> 01:26.044
+They were succeeded by programmers writing machine instructions.
+30
+01:26.044 --> 01:34.064
+They were succeeded by programmers writing machine instructions as binary code to be input one bit at a time by flipping
+31
+01:34.064 --> 01:34.954
+switches on the front of a computer.
+32
+01:34.954 --> 01:44.274
+Assembly language programming then put an end to that it lets a programmer use a human like language to tell the
+33
+01:44.274 --> 01:47.134
+computer to move data to locations in memory.
+34
+01:47.134 --> 01:48.224
+This is true.
+35
+01:48.224 --> 01:53.994
+If you did not know how crazy you got to read uh Uncle Bob has that whole history of programmers.
+36
+01:53.994 --> 01:59.854
+We programmer wrote the forward.
+37
+01:59.854 --> 02:02.164
+Hell yeah, I get nothing for saying that.
+38
+02:02.164 --> 02:06.164
+But it's actually a pretty sweet book.
+39
+02:06.164 --> 02:11.534
+Uh I read through it, it's great.
+40
+02:11.534 --> 02:15.854
+Uh, there's a lot of chatter in media that software developers
+41
+02:15.854 --> 02:20.654
+will soon lose their jobs to AI, I don't buy it.
+42
+02:20.654 --> 02:20.994
+Oh my gosh.
+43
+02:20.994 --> 02:22.254
+Wait a second.
+44
+02:22.254 --> 02:24.884
+Did I just get jabaited by this article?
+45
+02:24.884 --> 02:26.464
+And are we about to get hit with some
+46
+02:26.464 --> 02:29.204
+straight facts from O'Reilly software.
+47
+02:29.454 --> 02:37.694
+Timotheus O'Reilly is actually based.
+48
+02:37.694 --> 02:40.874
+It is not the end of programming.
+49
+02:40.874 --> 02:43.094
+It is the end of programming as we know it today.
+50
+02:43.094 --> 02:45.044
+That is not new.
+51
+02:45.044 --> 02:53.724
+Oh, okay, actually, no, this is not based.
+52
+02:53.724 --> 02:55.964
+The first programmers connected physical circuits
+53
+02:55.964 --> 03:00.714
+to perform each calculation.
+54
+03:00.714 --> 03:03.644
+This is true, if you did not know how crazy
+55
+03:03.644 --> 03:09.164
+you got to read uh Uncle Bob has that whole history of programmers.
+56
+03:09.164 --> 03:11.234
+We programmer wrote the forward.
+57
+03:11.454 --> 03:17.284
+Hell yeah, I get nothing for saying that, but it's actually a pretty sweet book.
+58
+03:17.284 --> 03:25.324
+Uh, I read through it, it's great.
+59
+03:25.324 --> 03:34.624
+Uh, this is not new.
+60
+03:34.624 --> 03:42.354
+All right, uh they were succeeded by programmers writing machine instructions as binary code to be input one bit at a time by flipping
+61
+03:42.354 --> 03:44.414
+switches on the front of a computer.
+62
+03:44.694 --> 03:50.374
+Yes.
+63
+03:50.374 --> 03:51.214
+I love that people are actually
+64
+03:51.214 --> 03:53.384
+attempting to co uhh.
+65
+03:53.384 --> 03:54.504
+Do are you actually
+66
+03:54.504 --> 03:57.134
+trying to are you actually trying
+67
+03:57.134 --> 04:06.174
+to correct my pronunciation of O'Reilly.
+68
+04:06.174 --> 04:12.154
+Dude, it's way more funny to call it O'Reilly.
+69
+04:12.154 --> 04:14.854
+Then it is to call it O'Reilly.
+70
+04:14.854 --> 04:16.174
+All right, there's a lot of chatter in media
+71
+04:16.174 --> 04:24.874
+that software developers will soon lose their jobs to AI, I don't buy it.
+72
+04:24.874 --> 04:28.334
+Oh my gosh.
+73
+04:28.334 --> 04:29.994
+Wait a second.
+74
+04:29.994 --> 04:32.164
+Did I just get jabaited by this article?
+75
+04:32.164 --> 04:33.804
+And are we about to get hit with some
+76
+04:33.804 --> 04:35.774
+straight facts from O'Reilly software.
+77
+04:35.774 --> 04:37.814
+Timotheus O'Reilly is actually based.
+78
+04:38.264 --> 04:47.224
+It is not the end of programming.
+79
+04:47.224 --> 04:57.494
+It is the end of programming as we know it today, that is not new.
+80
+04:57.494 --> 05:08.624
+Oh okay, actually, no, this is not based.
+81
+05:08.624 --> 05:35.334
+The first programmers connected physical circuits to perform each calculation.
+82
+05:35.334 --> 05:56.024
+This is true, Seymour Cray hand flipped in an operating system from memory on the Cray One if I'm not mistaken.
+83
+05:56.024 --> 05:57.884
+Pretty fantastic.
+84
+05:57.884 --> 06:00.094
+I love that people are actually attempting
+85
+06:00.094 --> 06:02.124
+to co uh do.
+86
+06:02.124 --> 06:02.534
+Are you actually
+87
+06:02.534 --> 06:05.154
+trying to are you actually trying
+88
+06:05.154 --> 06:06.724
+to correct my pronunciation
+89
+06:06.724 --> 06:09.224
+of O'Reilly.
+90
+06:09.224 --> 06:13.404
+Dude, it's way more funny to call it O'Reilly.
+91
+06:13.404 --> 06:15.334
+Then it is to call it O'Reilly.
+92
+06:15.634 --> 06:15.904
+Shut up.
+93
+06:15.904 --> 06:18.394
+They were succeeded by programmers writing
+94
+06:18.394 --> 06:22.464
+machine instructions as binary code to be input one bit at a time.
+95
+06:22.464 --> 06:26.714
+By flipping switches on the front of a computer.
+96
+06:26.714 --> 06:30.374
+Assembly language programming then put an end to that.
+97
+06:30.374 --> 06:40.654
+It lets a programmer use a human-like language to tell the computer to move data to locations in memory and perform calculations on it.
+98
+06:40.654 --> 06:41.984
+Then, development of even higher
+99
+06:41.984 --> 06:47.344
+level compiled languages like Fortran, COBOL.
+100
+06:47.344 --> 06:52.244
+ Uh to be completely fair.
+101
+06:52.634 --> 07:05.514
+Fortran, it didn't actually happen this way.
+102
+07:05.514 --> 07:17.674
+Fortran was actually uh 1958, which is just the very beginning of machine languages.
+103
+07:17.674 --> 07:21.524
+I believe you still have to feed things in by tape and all that kind of crazy stuff.
+104
+07:21.524 --> 07:25.124
+That's like why there's like a seven uh column requirement
+105
+07:25.124 --> 07:27.544
+in Fortran on the early Fortran code.
+106
+07:27.544 --> 07:30.104
+I know it's I'm just saying, Fortran was written
+107
+07:30.104 --> 07:33.414
+because there's this whole idea that compilers actually
+108
+07:33.414 --> 07:36.954
+aren't efficient, and so if you want efficiency, you
+109
+07:36.954 --> 07:39.574
+have to handwrite all of your own machine instructions.
+110
+07:39.574 --> 07:42.874
+Uh, and remember, you got to remember like back then,
+111
+07:42.874 --> 07:51.824
+it was like a kilohertz was like a like, dude, I'd kill a hurt too.

--- a/src/vtt/parser.ts
+++ b/src/vtt/parser.ts
@@ -362,7 +362,33 @@ export function parseVTT(content: string, options: ParseOptions = { preserveInde
       // Parse text content
       i++;
       let text = '';
-      while (i < lines.length && lines[i].trim() !== '') {
+      while (i < lines.length) {
+        const line = lines[i].trim();
+        
+        // Check if this line could be the start of a new cue
+        // It's a new cue if it's empty, a numeric identifier, or contains a timestamp
+        const isTimestampLine = line.includes('-->');
+        const isPotentialIdentifier = /^\d+$/.test(line);
+        const isEmptyLine = line === '';
+        
+        // If we encounter what looks like a new cue, stop collecting text
+        if (isEmptyLine || isPotentialIdentifier || isTimestampLine) {
+          break;
+        }
+        
+        // Check if the next line could be a timestamp line
+        // This helps with cases where a numeric identifier is immediately followed by a timestamp
+        if (i + 1 < lines.length) {
+          const nextLine = lines[i + 1].trim();
+          if (nextLine.includes('-->')) {
+            // If current line is a potential identifier and next line is a timestamp,
+            // this is likely the start of a new cue
+            if (isPotentialIdentifier || /^\d+$/.test(line)) {
+              break;
+            }
+          }
+        }
+        
         text += (text ? '\n' : '') + lines[i];
         i++;
       }


### PR DESCRIPTION
This pull request improves the handling of VTT files, particularly addressing edge cases and enhancing the parsing logic. The changes include adding a new test fixture, updating the parser logic, and adding new test cases.

### Key Changes:

**Enhancements to VTT Parsing:**

* [`src/vtt/parser.ts`](diffhunk://#diff-742d8f745954a325b68231f1339ebf23982686a302c71c84f66ec14e370c7235L365-R391): Improved the parsing logic to handle VTT files with no empty lines by checking for potential new cue indicators like timestamps, numeric identifiers, and empty lines.

**Test Additions and Updates:**

* [`src/__tests__/fixtures/subnospacing.vtt`](diffhunk://#diff-d099be0973174ce6e29eaa979d129e33ccde7e1169d1363d6bb9eaff97996da3R1-R335): Added a new VTT file fixture to test the parser's handling of files without empty lines.
* [`src/__tests__/vtt.test.ts`](diffhunk://#diff-b87b94b86047d3364bf768c289cd0bb585b59b28aab2bcd9bf1cdc592b122186R518-R560): Updated the test suite to include edge case tests for VTT files with no empty lines, ensuring the parser correctly handles and verifies the structure and content of such files.

**Dependency Additions:**

* [`src/__tests__/vtt.test.ts`](diffhunk://#diff-b87b94b86047d3364bf768c289cd0bb585b59b28aab2bcd9bf1cdc592b122186R5-R6): Added `fs` and `path` modules to read the new fixture file for testing.