### PR TITLE
Support markdown output

### DIFF
--- a/src/__tests__/format_detection.test.ts
+++ b/src/__tests__/format_detection.test.ts
@@ -128,6 +128,50 @@ Third line`;
             expect(result.cues).toHaveLength(5);
             expect(result.errors).toBeUndefined();
         });
+
+        test('detects VTT format embedded in markdown code block', () => {
+            const markdownVtt = `
+# Sample Subtitle
+
+Here is an example of VTT in a markdown code block:
+
+\`\`\`vtt
+WEBVTT
+
+00:00:01.916 --> 00:00:04.636
+It's here to change the game.
+
+00:00:06.296 --> 00:00:11.166
+With the power of AI, transforming the future.
+\`\`\`
+`;
+            const result = SubtitleUtils.detectAndParse(markdownVtt);
+            expect(result.type).toBe('vtt');
+            expect(result.cues).toHaveLength(2);
+            expect(result.errors).toBeUndefined();
+        });
+
+        test('detects SRT format embedded in markdown code block', () => {
+            const markdownSrt = `
+# Sample Subtitle
+
+Here is an example of SRT in a markdown code block:
+
+\`\`\`srt
+1
+00:00:01,916 --> 00:00:04,636
+It's here to change the game.
+
+2
+00:00:06,296 --> 00:00:11,166
+With the power of AI, transforming the future.
+\`\`\`
+`;
+            const result = SubtitleUtils.detectAndParse(markdownSrt);
+            expect(result.type).toBe('srt');
+            expect(result.cues).toHaveLength(2);
+            expect(result.errors).toBeUndefined();
+        });
     });
 
     describe('Format Conversion and Normalization', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,12 @@ import { generateSRT, formatTimestamp } from './srt/generator';
 import { generateVTT } from './vtt/generator';
 import { SubtitleUtils } from './utils';
 import { ParsedSubtitles, SubtitleCue, TimeShiftOptions, BuildOptions, ParsedVTT, ParseOptions } from './types';
-import { detectFormat } from './core-utils';
+import { detectFormat, extractFromMarkdown } from './core-utils';
 
 /**
  * Parse subtitle content in either SRT or VTT format.
  * The format will be automatically detected based on the content.
+ * Also supports content embedded in markdown code blocks like ```vtt or ```srt.
  * 
  * @param content - The subtitle content to parse
  * @param options - Optional parsing options
@@ -28,11 +29,14 @@ import { detectFormat } from './core-utils';
 function parse(content: string, options: ParseOptions = {}): ParsedSubtitles {
     const formatResult = detectFormat(content);
     
+    // Extract content from markdown if needed
+    const { content: extractedContent } = extractFromMarkdown(content);
+    
     switch (formatResult.type) {
         case 'srt':
-            return parseSRT(content, options);
+            return parseSRT(extractedContent, options);
         case 'vtt':
-            return parseVTT(content, options);
+            return parseVTT(extractedContent, options);
         default:
             return {
                 type: 'unknown',


### PR DESCRIPTION
This pull request introduces functionality to detect and extract subtitle content embedded in markdown code blocks. The changes span multiple files, adding new methods and updating existing ones to support this feature.

### New functionality for extracting subtitles from markdown:

* [`src/core-utils.ts`](diffhunk://#diff-eec6dabed60eea172e4fc12e923e0622b67492533a9951b16e45e64e071b097aR13-R32): Added a new function `extractFromMarkdown` to extract subtitle content from markdown code blocks, supporting both `vtt` and `srt` formats.
* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R482-R499): Added a static method `extractFromMarkdown` to the `SubtitleUtils` class to utilize the new extraction functionality.

### Updates to subtitle detection and parsing:

* [`src/core-utils.ts`](diffhunk://#diff-eec6dabed60eea172e4fc12e923e0622b67492533a9951b16e45e64e071b097aR48-R62): Updated the `detectFormat` function to use the new `extractFromMarkdown` function to detect and handle subtitle content embedded in markdown.
* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L499-R512): Modified the `detectAndParse` method in `SubtitleUtils` to extract content from markdown before proceeding with format detection and parsing. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L499-R512) [[2]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L513-R527)

### Test cases:

* [`src/__tests__/format_detection.test.ts`](diffhunk://#diff-de1c3d1fdc7035e87fc69d01b942865456e61dd1a149672e6c4226fa245e19a3R131-R174): Added new test cases to verify the detection of `vtt` and `srt` formats embedded in markdown code blocks.

### Documentation updates:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L7-R12): Updated comments to reflect the new functionality for handling subtitle content in markdown code blocks. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L7-R12) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R32-R39)